### PR TITLE
Allow user to exclude hosts from external calls checking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,5 +21,19 @@ Example output::
 
     FAILED (failures=1)
 
+Sometimes, you want to ignore hosts besides localhost. For example, you might
+be running tests in a containerized environment where dynamodb has the hostname
+`dynamodb` and `mysql` has the hostname `mysql`. To ignore these hosts,
+the `--vcr-ignore-host` option:
+
+    nosetests -v --with-detecthttp --vcr-ignore-host=www.example.com app/
+    test_one (app.tests.ExternalTestCase) ... ok
+    test_two (app.tests.ExternalTestCase) ... ok
+
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.042s
+
+    OK
+
 Under the hood, this wraps every test in a separate `VCR.py cassette <https://github.com/kevin1024/vcrpy>`__.
 Since VCR.py's hooks are in the stdlib, this approach won't detect requests made with clients like PycURL.

--- a/detecthttp/plugin.py
+++ b/detecthttp/plugin.py
@@ -71,11 +71,18 @@ class DetectHTTP(Plugin):
             default=False, dest="nodetecthttp",
             help="Disable detecthttp. Has the most precedence.")
 
+        parser.add_option(
+            '--vcr-ignore-host', action='append',
+            default=[], dest='ignored_hosts',
+            help="Ignore external calls to certain hosts")
+
     def configure(self, options, conf):
         super(DetectHTTP, self).configure(options, conf)
 
         if options.nodetecthttp:
             self.enabled = False
+
+        self.ignored_hosts = filter(bool, options.ignored_hosts) or []
 
         self.added_failure = False
         self.unmocked_report = UnmockedReport()
@@ -91,7 +98,8 @@ class DetectHTTP(Plugin):
         self._cassette_manager = vcr.use_cassette(cassette_name,
                                                   serializer='yaml',
                                                   record_mode='once',
-                                                  ignore_localhost=True)
+                                                  ignore_localhost=True,
+                                                  ignore_hosts=self.ignored_hosts)
 
         self._cassette = self._cassette_manager.__enter__()
         assert not self._cassette.rewound  # this cassette shouldn't be from disk


### PR DESCRIPTION
I'm using this plugin from a test runner (within kubernetes) that needs to be able to access whitelisted hosts other than localhost, so this PR would help us continue to use this useful plugin at Percolate. 