### PR TITLE
switch ignore-host from append to store+commas

### DIFF
--- a/detecthttp/plugin.py
+++ b/detecthttp/plugin.py
@@ -72,9 +72,9 @@ class DetectHTTP(Plugin):
             help="Disable detecthttp. Has the most precedence.")
 
         parser.add_option(
-            '--vcr-ignore-host', action='append',
-            default=[], dest='ignored_hosts',
-            help="Ignore external calls to certain hosts")
+            '--vcr-ignore-host', action='store',
+            default='', dest='ignored_hosts',
+            help="Ignore external calls to certain hosts. Accepts a comma-separated list.")
 
     def configure(self, options, conf):
         super(DetectHTTP, self).configure(options, conf)
@@ -82,7 +82,7 @@ class DetectHTTP(Plugin):
         if options.nodetecthttp:
             self.enabled = False
 
-        self.ignored_hosts = filter(bool, options.ignored_hosts) or []
+        self.ignored_hosts = filter(bool, options.ignored_hosts.split(','))
 
         self.added_failure = False
         self.unmocked_report = UnmockedReport()


### PR DESCRIPTION
This allows specifying multiple hosts from a setup.cfg, which is apparently impossible otherwise due to how those files are parsed.

It's technically a breaking change (for anyone passing the flag multiple times), so I'll bump to 1.0.0 when releasing it.